### PR TITLE
⚙️ [Maintenance]: CI actions updated and pinned to SHA with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci
@@ -29,7 +29,7 @@ jobs:
         run: npx vsce package
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vsix
           path: '*.vsix'
@@ -40,12 +40,12 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The CI workflow now uses the latest GitHub Actions pinned to commit SHAs, runs on Node.js 22 LTS, and Dependabot is configured to keep actions up to date automatically.

## Changed: CI workflow actions and Node.js version

All GitHub Actions in `build-and-publish.yml` are updated to their latest major versions and pinned to commit SHAs for supply-chain security:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v4` | `v6.0.2` (SHA pinned) |
| `actions/setup-node` | `v4` | `v6.4.0` (SHA pinned) |
| `actions/upload-artifact` | `v4` | `v7.0.1` (SHA pinned) |
| Node.js | 20 | 22 (current LTS) |

This resolves the Node.js 20 deprecation warnings shown in CI annotations.

## New: Dependabot for GitHub Actions

Dependabot is now configured to open weekly PRs when new action versions are available, ensuring the SHA-pinned references stay current.

## Technical Details

- Workflow file: `.github/workflows/build-and-publish.yml` — both `build` and `publish` jobs updated.
- Dependabot config: `.github/dependabot.yml` — `github-actions` ecosystem, weekly schedule.
- SHA pinning format: `uses: owner/action@<sha> # v<version>` — Dependabot recognizes this pattern and updates both the SHA and the version comment.