### PR TITLE
🩹 [Patch]: Publish job now uses pre-built VSIX artifact

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -39,18 +39,17 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vsix
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
-      - name: Install dependencies
-        run: npm ci
-
       - name: Publish to VS Code Marketplace
-        run: npx vsce publish
+        run: npx @vscode/vsce publish --packagePath *.vsix
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "remote-folder-url-button",
   "displayName": "Remote Folder URL Button",
   "description": "Adds an Explorer context action and a lightweight custom view with an inline button next to each folder to open its Git remote (file or folder) URL in the default browser.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "MariusStorhaug",
   "engines": {
     "vscode": "^1.84.0"


### PR DESCRIPTION
The publish job now publishes the exact VSIX artifact that was built and validated in CI, instead of rebuilding the extension from source. This eliminates any risk of non-determinism between the tested artifact and the published one.

- Fixes #3

## Changed: Publishing process

The `publish` job no longer checks out source code or installs dependencies. Instead, it downloads the VSIX artifact produced by the `build` job and publishes it directly using `--packagePath`. This guarantees that the extension published to the VS Code Marketplace is byte-for-byte identical to what was validated in CI.

## Technical Details

- Removed `actions/checkout` step from the `publish` job
- Removed `npm ci` (Install dependencies) step from the `publish` job
- Added `actions/download-artifact@v8.0.1` to retrieve the `vsix` artifact
- Updated publish command from `npx vsce publish` to `npx @vscode/vsce publish --packagePath *.vsix`
- Retained `actions/setup-node` since `npx` requires Node.js
- Bumped extension version from `0.0.3` to `0.0.4` to validate the new publish flow
- **Implementation plan progress**: All tasks completed (remove checkout, remove npm ci, add download-artifact, update publish command, verify workflow)