### PR TITLE
🩹 [Patch]: VSIX package contents verified before artifact upload

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,6 +28,21 @@ jobs:
       - name: Package extension
         run: npx vsce package
 
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vsix
+          path: '*.vsix'
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vsix
+
       - name: Verify VSIX contents
         run: |
           VSIX_FILE=$(ls *.vsix)
@@ -65,14 +80,8 @@ jobs:
 
           echo "All expected files found in VSIX package."
 
-      - name: Upload VSIX artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: vsix
-          path: '*.vsix'
-
   publish:
-    needs: build
+    needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,6 +28,43 @@ jobs:
       - name: Package extension
         run: npx vsce package
 
+      - name: Verify VSIX contents
+        run: |
+          VSIX_FILE=$(ls *.vsix)
+          echo "Verifying VSIX: $VSIX_FILE"
+
+          if [ ! -s "$VSIX_FILE" ]; then
+            echo "::error::VSIX file is missing or empty"
+            exit 1
+          fi
+
+          CONTENTS=$(unzip -l "$VSIX_FILE")
+          echo "$CONTENTS"
+
+          EXPECTED_FILES=(
+            "extension/src/extension.js"
+            "extension/package.json"
+            "extension/src/remoteUrl.js"
+            "extension/resources/"
+          )
+
+          MISSING=()
+          for file in "${EXPECTED_FILES[@]}"; do
+            if ! echo "$CONTENTS" | grep -q "$file"; then
+              MISSING+=("$file")
+            fi
+          done
+
+          if [ ${#MISSING[@]} -ne 0 ]; then
+            echo "::error::VSIX is missing expected files:"
+            for file in "${MISSING[@]}"; do
+              echo "  - $file"
+            done
+            exit 1
+          fi
+
+          echo "All expected files found in VSIX package."
+
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "remote-folder-url-button",
   "displayName": "Remote Folder URL Button",
   "description": "Adds an Explorer context action and a lightweight custom view with an inline button next to each folder to open its Git remote (file or folder) URL in the default browser.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publisher": "MariusStorhaug",
   "engines": {
     "vscode": "^1.84.0"


### PR DESCRIPTION
The build workflow now validates the VSIX package in a dedicated `test` job that runs between `build` and `publish`. Broken or incomplete packages are caught before the artifact reaches the marketplace. The extension version is bumped to 0.0.5.

- Fixes #4

## New: VSIX verification test job

A new `test` job sits between `build` and `publish` in the workflow pipeline:

```
build → test → publish
```

The `test` job:

1. Downloads the VSIX artifact produced by `build`
2. Confirms the file exists and has a non-zero size
3. Lists the package contents using `unzip -l`
4. Asserts the presence of expected files:
   - `extension/src/extension.js` (main entry point)
   - `extension/package.json` (manifest)
   - `extension/src/remoteUrl.js` (helper module)
   - `extension/resources/` (icon assets)
5. Fails CI with a descriptive `::error::` annotation if any file is missing

The `publish` job now depends on `test` (previously depended directly on `build`), so a failed verification blocks publishing.

## Changed: Version bump to 0.0.5

Extension version bumped from `0.0.4` to `0.0.5`.

## Technical Details

- Modified `.github/workflows/build-and-publish.yml`:
  - Moved "Upload VSIX artifact" step to the end of `build`
  - Added `test` job with `needs: build`, downloads artifact, runs verification script
  - Changed `publish` job to `needs: test` instead of `needs: build`
- Bumped `version` in `package.json` from `0.0.4` to `0.0.5`
- Uses bash array iteration and `grep` against `unzip -l` output for file presence checks
- No additional dependencies required (`unzip` is pre-installed on `ubuntu-latest`)
- **Implementation plan progress**: All 4 tasks from issue #4 completed