### PR TITLE
⚙️ [Maintenance]: CI actions updated to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -61,7 +61,7 @@ jobs:
       github.event.pull_request.merged == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Delete prereleases for this branch
         env:
@@ -104,7 +104,7 @@ jobs:
       pr-body: ${{ steps.calc.outputs.pr-body }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -306,7 +306,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate metadata in package.json
         env:
@@ -370,7 +370,7 @@ jobs:
           jq '{version, repository, license, homepage, bugs, description}' package.json
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
 
@@ -384,7 +384,7 @@ jobs:
         run: npx @vscode/vsce package --no-update-package-json
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vsix
           path: '*.vsix'
@@ -395,7 +395,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: vsix
 
@@ -430,12 +430,12 @@ jobs:
     if: needs.version.outputs.should-release == 'true' && inputs.publish
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: vsix
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
 
@@ -458,10 +458,10 @@ jobs:
     if: needs.version.outputs.should-release == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: vsix
 

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -384,7 +384,7 @@ jobs:
         run: npx @vscode/vsce package --no-update-package-json
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vsix
           path: '*.vsix'
@@ -395,7 +395,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vsix
 
@@ -430,7 +430,7 @@ jobs:
     if: needs.version.outputs.should-release == 'true' && inputs.publish
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vsix
 
@@ -461,7 +461,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vsix
 

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -61,7 +61,7 @@ jobs:
       github.event.pull_request.merged == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Delete prereleases for this branch
         env:
@@ -104,7 +104,7 @@ jobs:
       pr-body: ${{ steps.calc.outputs.pr-body }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -306,7 +306,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate metadata in package.json
         env:
@@ -370,7 +370,7 @@ jobs:
           jq '{version, repository, license, homepage, bugs, description}' package.json
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
 
@@ -384,7 +384,7 @@ jobs:
         run: npx @vscode/vsce package --no-update-package-json
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: vsix
           path: '*.vsix'
@@ -395,7 +395,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: vsix
 
@@ -430,12 +430,12 @@ jobs:
     if: needs.version.outputs.should-release == 'true' && inputs.publish
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: vsix
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
 
@@ -458,10 +458,10 @@ jobs:
     if: needs.version.outputs.should-release == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: vsix
 


### PR DESCRIPTION
CI jobs no longer produce Node.js 20 deprecation warnings. All GitHub Actions in the build workflow are updated to their latest releases that run on Node.js 24 natively and pinned to commit SHAs for supply-chain security, ahead of the June 2, 2026 enforcement deadline.

- Fixes #9

## Changed: Action versions in CI workflow

All `actions/` org action references in `.github/workflows/build-vscode-extension.yml` are updated to their latest Node.js 24-compatible releases, pinned to commit SHAs with patch-level tag comments:

| Action | Previous | Updated | SHA |
| --- | --- | --- | --- |
| `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-node` | `v4` | `v6.4.0` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
| `actions/upload-artifact` | `v4` | `v7.0.1` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/download-artifact` | `v4` | `v8.0.1` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |

All jobs (`Calculate Version`, `Build`, `Test`, `Publish`, `Cleanup Prereleases`) use the updated versions. No workflow logic, inputs, outputs, or job structure changed.

## Technical Details

- **File changed:** `.github/workflows/build-vscode-extension.yml` (10 action references updated)
- **SHA pinning:** All actions are pinned to full commit SHAs (verified via GitHub API) with a `# vX.Y.Z` comment for human readability. This prevents supply-chain attacks via tag mutation.
- **Version verification:** Latest releases confirmed via `GET /repos/{owner}/{repo}/releases/latest` and commit SHAs verified via `GET /repos/{owner}/{repo}/commits/{tag}` on 2026-05-01.
- **Breaking change assessment:**
  - `checkout@v6`: Persist-credentials stored under `$RUNNER_TEMP` instead of local git config. No impact — workflow uses `GH_TOKEN` env var directly.
  - `setup-node@v6`: Automatic npm caching when `packageManager` field exists in `package.json`. Transparent for this workflow (no `packageManager` field used).
  - `upload-artifact@v7`: Adds optional `archive: false` for direct (unzipped) uploads. Default behavior (zipped) unchanged. ESM migration transparent to callers.
  - `download-artifact@v8`: No longer attempts to unzip non-zipped downloads (checks Content-Type). Digest mismatch now errors by default. Both changes are compatible — workflow uploads with default zipping.
- **Implementation plan progress:** Tasks 1–5 completed (version checks and all action reference updates). Task 6 (verify CI passes) will be confirmed when this PR's CI runs complete.