### PR TITLE
🩹 [Patch]: Open Remote URL action available in Explorer and Source Control views

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    types: [ opened, synchronize, reopened, closed ]
+    types: [ opened, synchronize, reopened, closed, labeled ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -381,7 +381,15 @@ jobs:
         run: npm run lint --if-present
 
       - name: Package extension
-        run: npx @vscode/vsce package --no-update-package-json
+        env:
+          IS_PRERELEASE: ${{ needs.version.outputs.is-prerelease }}
+        shell: bash
+        run: |
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            npx @vscode/vsce package --no-update-package-json --pre-release
+          else
+            npx @vscode/vsce package --no-update-package-json
+          fi
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -375,7 +375,7 @@ jobs:
           node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --omit=optional
 
       - name: Lint
         run: npm run lint --if-present
@@ -386,9 +386,9 @@ jobs:
         shell: bash
         run: |
           if [ "$IS_PRERELEASE" = "true" ]; then
-            npx @vscode/vsce package --no-update-package-json --pre-release
+            ./node_modules/.bin/vsce package --no-update-package-json --pre-release
           else
-            npx @vscode/vsce package --no-update-package-json
+            ./node_modules/.bin/vsce package --no-update-package-json
           fi
 
       - name: Upload VSIX artifact
@@ -451,6 +451,7 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
           IS_PRERELEASE: ${{ needs.version.outputs.is-prerelease }}
+          npm_config_omit: optional
         shell: bash
         run: |
           if [ "$IS_PRERELEASE" = "true" ]; then

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -289,6 +289,10 @@ jobs:
             EXISTING_COUNT=$(gh release list --json tagName,isPrerelease --jq "[.[] | select(.isPrerelease == true) | select(.tagName | startswith(\"${VERSION_PREFIX}${NEW_VERSION}-${PRERELEASE_ID}\"))] | length" 2>/dev/null || echo "0")
             NEXT_NUM=$((EXISTING_COUNT + 1))
             NEW_VERSION="${NEW_VERSION}-${PRERELEASE_ID}.${NEXT_NUM}"
+            # VS Code Marketplace requires x.y.z format without pre-release identifiers.
+            # Use the workflow run number as the patch to guarantee a unique, monotonically
+            # increasing version for each prerelease CI run, avoiding "already exists" errors.
+            PACKAGE_VERSION="${MAJOR}.${MINOR}.${GITHUB_RUN_NUMBER}"
           fi
 
           echo "Calculated new version: $NEW_VERSION (package version: $PACKAGE_VERSION, bump: $BUMP, prerelease: $IS_PRERELEASE)"

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -135,15 +135,41 @@ jobs:
           PATCH_ARR=("${PATCH_ARR[@]// /}")
           IGNORE_ARR=("${IGNORE_ARR[@]// /}")
 
-          # Get latest stable release version (exclude prereleases)
+          # Helper: query the VS Code Marketplace for the latest published version of this extension.
+          # Returns the version string (e.g. "1.2.3") or an empty string if not found.
+          get_marketplace_version() {
+            local publisher="$1"
+            local ext_name="$2"
+            curl -s -X POST \
+              -H "Content-Type: application/json" \
+              -H "Accept: application/json; api-version=3.0-preview.1" \
+              --data "{\"filters\":[{\"criteria\":[{\"filterType\":7,\"value\":\"${publisher}.${ext_name}\"}]}],\"flags\":512}" \
+              "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
+              | jq -r '.results[0].extensions[0].versions[0].version // empty' 2>/dev/null \
+              || echo ""
+          }
+
+          # Get latest stable release version (exclude prereleases).
+          # Falls back to the VS Code Marketplace published version so that repositories
+          # which were published before GitHub releases were introduced still calculate
+          # version bumps relative to the real published baseline, not 0.0.0.
           LATEST_TAG=$(gh release list --exclude-drafts --json tagName,isPrerelease --jq '[.[] | select(.isPrerelease == false)][0].tagName // empty' 2>/dev/null || echo "")
-          if [ -z "$LATEST_TAG" ]; then
-            LATEST_VERSION="0.0.0"
-            echo "No previous stable release found. Starting from 0.0.0"
-          else
+          if [ -n "$LATEST_TAG" ]; then
             # Strip version prefix
             LATEST_VERSION="${LATEST_TAG#$VERSION_PREFIX}"
             echo "Latest stable release: $LATEST_TAG (version: $LATEST_VERSION)"
+          else
+            # No GitHub release — try the VS Code Marketplace
+            PUBLISHER=$(jq -r '.publisher' package.json)
+            EXT_NAME=$(jq -r '.name' package.json)
+            MARKETPLACE_VERSION=$(get_marketplace_version "$PUBLISHER" "$EXT_NAME")
+            if [ -n "$MARKETPLACE_VERSION" ]; then
+              LATEST_VERSION="$MARKETPLACE_VERSION"
+              echo "No GitHub release found. Using VS Code Marketplace version as base: $LATEST_VERSION"
+            else
+              LATEST_VERSION="0.0.0"
+              echo "No GitHub release or Marketplace version found. Starting from 0.0.0"
+            fi
           fi
 
           # Parse semver components

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -135,37 +135,56 @@ jobs:
           PATCH_ARR=("${PATCH_ARR[@]// /}")
           IGNORE_ARR=("${IGNORE_ARR[@]// /}")
 
-          # Helper: query the VS Code Marketplace for the latest published version of this extension.
+          # Helper: query the VS Code Marketplace for a published version of this extension.
+          # Usage: get_marketplace_version <publisher> <ext_name> [stable|any]
+          #   stable (default) - latest version that is NOT marked as a pre-release
+          #   any              - absolute latest version regardless of pre-release flag
           # Returns the version string (e.g. "1.2.3") or an empty string if not found.
           get_marketplace_version() {
             local publisher="$1"
             local ext_name="$2"
-            curl -s -X POST \
+            local mode="${3:-stable}"
+            local response
+            response=$(curl -s -X POST \
               -H "Content-Type: application/json" \
               -H "Accept: application/json; api-version=3.0-preview.1" \
               --data "{\"filters\":[{\"criteria\":[{\"filterType\":7,\"value\":\"${publisher}.${ext_name}\"}]}],\"flags\":512}" \
-              "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
-              | jq -r '.results[0].extensions[0].versions[0].version // empty' 2>/dev/null \
-              || echo ""
+              "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" 2>/dev/null) || true
+            if [ -z "$response" ]; then echo ""; return; fi
+            if [ "$mode" = "any" ]; then
+              # First version in the list is the most recently published (stable or pre-release)
+              echo "$response" | jq -r '.results[0].extensions[0].versions[0].version // empty' 2>/dev/null || echo ""
+            else
+              # Stable: skip versions flagged as pre-release via the extension property
+              echo "$response" | jq -r '[
+                .results[0].extensions[0].versions[] |
+                select(
+                  (.properties // [] |
+                   map(select(.key == "Microsoft.VisualStudio.Code.PreRelease" and .value == "true")) |
+                   length) == 0
+              ) | .version][0] // empty' 2>/dev/null || echo ""
+            fi
           }
 
+          # Read publisher and extension name once from package.json (always checked out).
+          PUBLISHER=$(jq -r '.publisher' package.json)
+          EXT_NAME=$(jq -r '.name' package.json)
+
           # Get latest stable release version (exclude prereleases).
-          # Falls back to the VS Code Marketplace published version so that repositories
-          # which were published before GitHub releases were introduced still calculate
-          # version bumps relative to the real published baseline, not 0.0.0.
+          # Priority: (1) latest stable GitHub release tag,
+          #           (2) latest stable VS Code Marketplace version,
+          #           (3) 0.0.0 as a last resort.
+          # This ensures repositories published to the Marketplace before GitHub releases
+          # were introduced still calculate version bumps from the real published baseline.
           LATEST_TAG=$(gh release list --exclude-drafts --json tagName,isPrerelease --jq '[.[] | select(.isPrerelease == false)][0].tagName // empty' 2>/dev/null || echo "")
           if [ -n "$LATEST_TAG" ]; then
-            # Strip version prefix
             LATEST_VERSION="${LATEST_TAG#$VERSION_PREFIX}"
             echo "Latest stable release: $LATEST_TAG (version: $LATEST_VERSION)"
           else
-            # No GitHub release — try the VS Code Marketplace
-            PUBLISHER=$(jq -r '.publisher' package.json)
-            EXT_NAME=$(jq -r '.name' package.json)
-            MARKETPLACE_VERSION=$(get_marketplace_version "$PUBLISHER" "$EXT_NAME")
-            if [ -n "$MARKETPLACE_VERSION" ]; then
-              LATEST_VERSION="$MARKETPLACE_VERSION"
-              echo "No GitHub release found. Using VS Code Marketplace version as base: $LATEST_VERSION"
+            MARKETPLACE_STABLE=$(get_marketplace_version "$PUBLISHER" "$EXT_NAME" "stable")
+            if [ -n "$MARKETPLACE_STABLE" ]; then
+              LATEST_VERSION="$MARKETPLACE_STABLE"
+              echo "No GitHub release found. Using VS Code Marketplace stable version as base: $LATEST_VERSION"
             else
               LATEST_VERSION="0.0.0"
               echo "No GitHub release or Marketplace version found. Starting from 0.0.0"
@@ -316,9 +335,17 @@ jobs:
             NEXT_NUM=$((EXISTING_COUNT + 1))
             NEW_VERSION="${NEW_VERSION}-${PRERELEASE_ID}.${NEXT_NUM}"
             # VS Code Marketplace requires x.y.z format without pre-release identifiers.
-            # Use the workflow run number as the patch to guarantee a unique, monotonically
-            # increasing version for each prerelease CI run, avoiding "already exists" errors.
-            PACKAGE_VERSION="${MAJOR}.${MINOR}.${GITHUB_RUN_NUMBER}"
+            # Use the absolute latest marketplace version (stable OR prerelease) as the base
+            # and bump its patch by 1. This guarantees each CI push to the PR produces a
+            # version higher than anything already published, avoiding "already exists" errors.
+            MARKETPLACE_LATEST=$(get_marketplace_version "$PUBLISHER" "$EXT_NAME" "any")
+            if [ -n "$MARKETPLACE_LATEST" ]; then
+              IFS='.' read -r MP_MAJ MP_MIN MP_PAT <<< "$MARKETPLACE_LATEST"
+              MP_PAT=$((MP_PAT + 1))
+              PACKAGE_VERSION="${MP_MAJ}.${MP_MIN}.${MP_PAT}"
+              echo "Marketplace latest: $MARKETPLACE_LATEST — using $PACKAGE_VERSION as prerelease package version"
+            fi
+            # If the marketplace query failed, PACKAGE_VERSION keeps the label-bump value
           fi
 
           echo "Calculated new version: $NEW_VERSION (package version: $PACKAGE_VERSION, bump: $BUMP, prerelease: $IS_PRERELEASE)"

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -97,6 +97,7 @@ jobs:
       github.event.pull_request.merged == false)"
     outputs:
       version: ${{ steps.calc.outputs.version }}
+      package-version: ${{ steps.calc.outputs.package-version }}
       should-release: ${{ steps.calc.outputs.should-release }}
       is-prerelease: ${{ steps.calc.outputs.is-prerelease }}
       pr-number: ${{ steps.calc.outputs.pr-number }}
@@ -199,6 +200,7 @@ jobs:
                 if [ "$label" = "$ignore" ]; then
                   echo "Ignore label '$label' found. Skipping release."
                   echo "version=${MAJOR}.${MINOR}.${PATCH}" >> "$GITHUB_OUTPUT"
+                  echo "package-version=${MAJOR}.${MINOR}.${PATCH}" >> "$GITHUB_OUTPUT"
                   echo "should-release=false" >> "$GITHUB_OUTPUT"
                   echo "is-prerelease=false" >> "$GITHUB_OUTPUT"
                   echo "pr-number=" >> "$GITHUB_OUTPUT"
@@ -265,6 +267,7 @@ jobs:
             *)
               echo "No version bump determined."
               echo "version=${MAJOR}.${MINOR}.${PATCH}" >> "$GITHUB_OUTPUT"
+              echo "package-version=${MAJOR}.${MINOR}.${PATCH}" >> "$GITHUB_OUTPUT"
               echo "should-release=false" >> "$GITHUB_OUTPUT"
               echo "is-prerelease=false" >> "$GITHUB_OUTPUT"
               echo "pr-number=" >> "$GITHUB_OUTPUT"
@@ -275,6 +278,7 @@ jobs:
           esac
 
           NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          PACKAGE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
 
           # Add prerelease suffix for prerelease builds
           if [ "$IS_PRERELEASE" = "true" ]; then
@@ -287,8 +291,9 @@ jobs:
             NEW_VERSION="${NEW_VERSION}-${PRERELEASE_ID}.${NEXT_NUM}"
           fi
 
-          echo "Calculated new version: $NEW_VERSION (bump: $BUMP, prerelease: $IS_PRERELEASE)"
+          echo "Calculated new version: $NEW_VERSION (package version: $PACKAGE_VERSION, bump: $BUMP, prerelease: $IS_PRERELEASE)"
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
           echo "should-release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
           echo "is-prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
@@ -311,7 +316,7 @@ jobs:
       - name: Generate metadata in package.json
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.version.outputs.version }}
+          VERSION: ${{ needs.version.outputs.package-version }}
         shell: bash
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Remote Folder URL Button
 
-A lightweight VS Code extension that lets you open the Git remote URL for any file or folder:
+A lightweight VS Code extension that adds a context menu action to open the Git remote URL for any file or folder in your default browser:
 
-- **Built-in Explorer**: Right-click a file or folder → **Open Remote URL in Browser**
-- **Custom view**: *Explorer → Remote Folders* shows your folder tree with inline buttons to open remote URLs
+- **Explorer**: Right-click a file or folder → **Open Remote URL in Browser**
+- **Source Control**: Right-click a changed file → **Open Remote URL in Browser**
 
 ## Supported Hosts
 
@@ -13,11 +13,6 @@ A lightweight VS Code extension that lets you open the Git remote URL for any fi
 | GitLab | `-/tree/<branch>/<path>` | `-/blob/<branch>/<path>` |
 | Bitbucket | `src/<branch>/<path>` | `src/<branch>/<path>` |
 | Azure DevOps | `?path=/path&version=GB<branch>` | same |
-
-## Keyboard Shortcuts
-
-- **`Ctrl+Shift+O`** (macOS: `Cmd+Shift+O`) — Open remote URL for the selected item in Explorer
-- **`Ctrl+Alt+O`** (macOS: `Cmd+Alt+O`) — Open remote URL for the active file
 
 ## Development
 
@@ -50,7 +45,6 @@ The publish step requires a `VSCE_PAT` repository secret containing a Visual Stu
 
 ## Settings
 
-- `remoteFolders.exclude` — Folder names to hide in the custom *Remote Folders* view
 - `remoteFolders.preferBranch` — Fallback branch when HEAD cannot be determined
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "remote-folder-url-button",
-  "version": "0.0.3",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remote-folder-url-button",
-      "version": "0.0.3",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/vscode": "^1.84.0",
-        "@vscode/vsce": "^3.0.0",
+        "@vscode/vsce": "^3.9.1",
         "eslint": "^9.0.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/vscode": "^1.84.0",
+        "@eslint/js": "^10.0.1",
+        "@types/vscode": "^1.118.0",
         "@vscode/vsce": "^3.9.1",
-        "eslint": "^9.0.0"
+        "eslint": "^10.3.0"
       },
       "engines": {
         "vscode": "^1.84.0"
@@ -270,129 +271,128 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
@@ -779,6 +779,13 @@
       "dependencies": {
         "@textlint/ast-node-types": "15.6.0"
       }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1338,16 +1345,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1861,33 +1858,30 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -1897,8 +1891,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1906,7 +1899,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -1921,30 +1914,32 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1967,6 +1962,29 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1974,19 +1992,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2382,19 +2416,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/globby": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
@@ -2615,23 +2636,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -3050,13 +3054,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -3460,19 +3457,6 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/parse-json": {
       "version": "8.3.0",
@@ -3881,16 +3865,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/reusify": {
@@ -4305,19 +4279,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/structured-source": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-folder-url-button",
   "displayName": "Remote Folder URL Button",
-  "description": "Adds an Explorer context action and a lightweight custom view with an inline button next to each folder to open its Git remote (file or folder) URL in the default browser.",
+  "description": "Adds a context menu action in the Explorer and Source Control views to open the Git remote URL for a file or folder in your default browser.",
   "version": "0.0.0",
   "publisher": "MariusStorhaug",
   "engines": {
@@ -16,106 +16,34 @@
       {
         "command": "remoteFolders.openRemote",
         "title": "Open Remote URL in Browser",
-        "category": "Remote Folders",
-        "icon": {
-          "light": "resources/open-external-light.svg",
-          "dark": "resources/open-external-dark.svg"
-        }
-      },
-      {
-        "command": "remoteFolders.openRemoteFromExplorer",
-        "title": "Open Remote URL in Browser",
-        "category": "Remote Folders",
-        "icon": {
-          "light": "resources/open-external-light.svg",
-          "dark": "resources/open-external-dark.svg"
-        }
-      },
-      {
-        "command": "remoteFolders.refresh",
-        "title": "Refresh",
-        "category": "Remote Folders",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "remoteFolders.openRemoteForActiveFile",
-        "title": "Open Remote URL for Current File/Folder",
         "category": "Remote Folders"
       }
     ],
-    "views": {
-      "explorer": [
-        {
-          "id": "remoteFoldersView",
-          "name": "Remote Folders",
-          "icon": "$(globe)"
-        }
-      ]
-    },
     "menus": {
+      "commandPalette": [
+        {
+          "command": "remoteFolders.openRemote",
+          "when": "false"
+        }
+      ],
       "explorer/context": [
         {
-          "command": "remoteFolders.openRemoteFromExplorer",
+          "command": "remoteFolders.openRemote",
           "group": "navigation@1",
           "when": "resourceScheme == file && gitOpenRepositoryCount != 0"
         }
       ],
-      "view/item/context": [
+      "scm/resourceState/context": [
         {
           "command": "remoteFolders.openRemote",
-          "when": "view == remoteFoldersView && viewItem == rf.folder",
-          "group": "navigation@1"
-        }
-      ],
-      "view/title": [
-        {
-          "command": "remoteFolders.refresh",
-          "when": "view == remoteFoldersView",
-          "group": "navigation"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "remoteFolders.openRemoteForActiveFile",
-          "when": "gitOpenRepositoryCount != 0"
+          "group": "navigation@1",
+          "when": "scmProvider == git"
         }
       ]
     },
-    "keybindings": [
-      {
-        "command": "remoteFolders.openRemoteFromExplorer",
-        "key": "ctrl+shift+o",
-        "mac": "cmd+shift+o",
-        "when": "filesExplorerFocus && resourceScheme == file"
-      },
-      {
-        "command": "remoteFolders.openRemote",
-        "key": "ctrl+shift+o",
-        "mac": "cmd+shift+o",
-        "when": "focusedView == remoteFoldersView"
-      },
-      {
-        "command": "remoteFolders.openRemoteForActiveFile",
-        "key": "ctrl+alt+o",
-        "mac": "cmd+alt+o"
-      }
-    ],
     "configuration": {
       "title": "Remote Folder URL Button",
       "properties": {
-        "remoteFolders.exclude": {
-          "type": "array",
-          "default": [
-            ".git",
-            ".vscode",
-            "node_modules",
-            "dist",
-            "out",
-            "target",
-            ".idea"
-          ],
-          "description": "Folder names to exclude from the custom view."
-        },
         "remoteFolders.preferBranch": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,13 @@
           "group": "navigation@1",
           "when": "scmProvider == git"
         }
+      ],
+      "scm/resourceFolder/context": [
+        {
+          "command": "remoteFolders.openRemote",
+          "group": "navigation@1",
+          "when": "scmProvider == git"
+        }
       ]
     },
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -57,11 +57,7 @@
         {
           "command": "remoteFolders.openRemoteFromExplorer",
           "group": "navigation@1",
-          "when": "resourceScheme == file && gitOpenRepositoryCount != 0",
-          "icon": {
-            "light": "resources/open-external-light.svg",
-            "dark": "resources/open-external-dark.svg"
-          }
+          "when": "resourceScheme == file && gitOpenRepositoryCount != 0"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@types/vscode": "^1.84.0",
-    "@vscode/vsce": "^3.0.0",
+    "@vscode/vsce": "^3.9.1",
     "eslint": "^9.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "publisher": "MariusStorhaug",
   "engines": {
-    "vscode": "^1.84.0"
+    "vscode": "^1.118.0"
   },
   "categories": [
     "Other"

--- a/package.json
+++ b/package.json
@@ -70,8 +70,9 @@
     "publish": "vsce publish"
   },
   "devDependencies": {
-    "@types/vscode": "^1.84.0",
+    "@eslint/js": "^10.0.1",
+    "@types/vscode": "^1.118.0",
     "@vscode/vsce": "^3.9.1",
-    "eslint": "^9.0.0"
+    "eslint": "^10.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,11 +68,7 @@
         {
           "command": "remoteFolders.openRemote",
           "when": "view == remoteFoldersView && viewItem == rf.folder",
-          "group": "inline@1",
-          "icon": {
-            "light": "resources/open-external-light.svg",
-            "dark": "resources/open-external-dark.svg"
-          }
+          "group": "navigation@1"
         }
       ],
       "view/title": [

--- a/resources/open-external-dark.svg
+++ b/resources/open-external-dark.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M1.5 1.5H7V3H3V13H13V9H14.5V14.5H1.5V1.5Z" fill="#C5C5C5"/>
-  <path d="M9 1.5H14.5V7H13V4.06L7.53 9.53L6.47 8.47L11.94 3H9V1.5Z" fill="#C5C5C5"/>
-</svg>

--- a/resources/open-external-light.svg
+++ b/resources/open-external-light.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M1.5 1.5H7V3H3V13H13V9H14.5V14.5H1.5V1.5Z" fill="#424242"/>
-  <path d="M9 1.5H14.5V7H13V4.06L7.53 9.53L6.47 8.47L11.94 3H9V1.5Z" fill="#424242"/>
-</svg>

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,7 +1,6 @@
 // @ts-check
 const vscode = require('vscode');
 const path = require('path');
-const fs = require('fs').promises;
 const { normalizeRemote, composeFolderUrl, composeFileUrl } = require('./remoteUrl');
 
 /**
@@ -23,8 +22,7 @@ async function getGitApi() {
         if (!gitExt.isActive) {
             await gitExt.activate();
         }
-        const api = gitExt.exports.getAPI(1);
-        return api;
+        return gitExt.exports.getAPI(1);
     } catch {
         return undefined;
     }
@@ -38,7 +36,7 @@ async function getGitApi() {
 function getRepositoryForUri(gitApi, uri) {
     if (!gitApi) return undefined;
     const repos = gitApi.repositories || [];
-    let chosen = undefined;
+    let chosen;
     for (const r of repos) {
         const root = r.rootUri;
         if (uri.fsPath.startsWith(root.fsPath)) {
@@ -58,14 +56,10 @@ function getRepositoryForUri(gitApi, uri) {
 async function detectResourceKind(uri) {
     try {
         const stat = await vscode.workspace.fs.stat(uri);
-        if ((stat.type & vscode.FileType.Directory) !== 0) {
-            return 'directory';
-        }
-        if ((stat.type & vscode.FileType.File) !== 0) {
-            return 'file';
-        }
+        if ((stat.type & vscode.FileType.Directory) !== 0) return 'directory';
+        if ((stat.type & vscode.FileType.File) !== 0) return 'file';
     } catch {
-        // ignore fallthrough
+        // ignore
     }
     return 'unknown';
 }
@@ -100,142 +94,56 @@ async function computeRemoteUrl(uri, hint) {
     const branch = (head && head.name) || (vscode.workspace.getConfiguration('remoteFolders').get('preferBranch') || 'HEAD');
 
     const rel = toPosix(path.relative(repo.rootUri.fsPath, uri.fsPath));
-    const relClean = rel === '' ? '' : rel;
 
     /** @type {'file' | 'directory' | 'unknown'} */
     let kind = hint || 'unknown';
-    if (!kind || kind === 'unknown') {
+    if (kind === 'unknown') {
         kind = await detectResourceKind(uri);
     }
 
-    const treatAsDirectory = kind === 'directory' || relClean === '';
+    const treatAsDirectory = kind === 'directory' || rel === '';
     if (treatAsDirectory) {
-        return composeFolderUrl(info, branch, relClean);
+        return composeFolderUrl(info, branch, rel);
     }
 
-    if (!relClean) {
+    if (!rel) {
         throw new Error('Unable to determine repository-relative path for the selected file.');
     }
 
-    return composeFileUrl(info, branch, relClean);
+    return composeFileUrl(info, branch, rel);
+}
+
+/**
+ * Resolve a URI from any context-menu argument shape (Uri, TreeItem, SCM resource state, etc.)
+ * @param {any} target
+ * @returns {vscode.Uri | undefined}
+ */
+function resolveUri(target) {
+    if (!target) return undefined;
+    if (target instanceof vscode.Uri) return target;
+    if (target.resourceUri instanceof vscode.Uri) return target.resourceUri;
+    if (target.uri instanceof vscode.Uri) return target.uri;
+    return undefined;
 }
 
 /**
  * @param {any} target
  */
 async function openRemoteForTarget(target) {
-    /** @type {vscode.Uri | undefined} */
-    let uri;
-    if (!target) {
-        return;
-    }
-    if (target instanceof vscode.Uri) {
-        uri = target;
-    } else if (target.resourceUri) {
-        uri = target.resourceUri;
-    } else if (target.uri) {
-        uri = target.uri;
-    }
-
+    const uri = resolveUri(target);
     if (!uri) {
         vscode.window.showErrorMessage('Could not determine a URI for this item.');
         return;
     }
 
-    let kind = 'unknown';
+    const kind = await detectResourceKind(uri);
     try {
-        kind = await detectResourceKind(uri);
-        if (kind === 'unknown') {
-            vscode.window.showWarningMessage('Could not determine whether the item is a file or folder. Attempting to open anyway.');
-        }
-    } catch {
-        // ignore and attempt anyway
-    }
-
-    const url = await computeRemoteUrl(uri, /** @type {any} */(kind));
-    await vscode.env.openExternal(vscode.Uri.parse(url));
-    vscode.window.setStatusBarMessage('Opened remote URL: ' + url, 3000);
-}
-
-/** @type {import('vscode').TreeDataProvider<any>} */
-class RemoteFoldersProvider {
-    constructor() {
-        this._onDidChangeTreeData = new vscode.EventEmitter();
-        this.onDidChangeTreeData = this._onDidChangeTreeData.event;
-    }
-
-    refresh() { this._onDidChangeTreeData.fire(); }
-
-    /**
-     * @param {any} element
-     * @returns {Promise<any[]>}
-     */
-    async getChildren(element) {
-        /** @type {readonly vscode.WorkspaceFolder[]} */
-        const folders = vscode.workspace.workspaceFolders || [];
-        const excludes = vscode.workspace.getConfiguration('remoteFolders').get('exclude') || [];
-        const excludeSet = new Set(excludes);
-        if (!element) {
-            return folders.map((/** @type {vscode.WorkspaceFolder} */ f) => ({ uri: f.uri, depth: 0, label: path.basename(f.uri.fsPath) }));
-        }
-        try {
-            /** @type {any[]} */
-            const entries = await fs.readdir(element.uri.fsPath, { withFileTypes: true });
-            const dirs = entries
-                .filter((/** @type {any} */ e) => e.isDirectory())
-                .map((/** @type {any} */ e) => e.name);
-            const filtered = dirs.filter((/** @type {string} */ name) => !excludeSet.has(name));
-            return filtered.map((/** @type {string} */ name) => ({
-                uri: vscode.Uri.file(path.join(element.uri.fsPath, name)),
-                depth: (element.depth || 0) + 1,
-                label: name
-            }));
-        } catch {
-            return [];
-        }
-    }
-
-    /**
-     * @param {any} element
-     * @returns {Promise<vscode.TreeItem>}
-     */
-    async getTreeItem(element) {
-        const item = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
-        item.resourceUri = element.uri;
-        item.contextValue = 'rf.folder';
-
-        let remoteUrl = undefined;
-
-        try {
-            const gitApi = await getGitApi();
-            if (gitApi) {
-                const repo = getRepositoryForUri(gitApi, element.uri);
-                if (repo) {
-                    /** @type {Array<{name?: string, fetchUrl?: string, pushUrl?: string}>} */
-                    const remotes = repo.state.remotes || [];
-                    const origin = remotes.find(r => r.name === 'origin') || remotes[0];
-                    if (origin && (origin.fetchUrl || origin.pushUrl)) {
-                        item.description = '🌐';
-                        remoteUrl = await computeRemoteUrl(element.uri, 'directory');
-                    }
-                }
-            }
-        } catch {
-            // Ignore errors
-        }
-
-        if (remoteUrl) {
-            const tooltip = new vscode.MarkdownString();
-            tooltip.isTrusted = true;
-            tooltip.appendMarkdown(`\`${toPosix(element.uri.fsPath)}\``);
-            tooltip.appendMarkdown(`\n\n[Open remote folder](${remoteUrl})`);
-            tooltip.appendMarkdown('\n\nUse the inline globe button to open in your browser.');
-            item.tooltip = tooltip;
-        } else {
-            item.tooltip = element.uri.fsPath;
-        }
-
-        return item;
+        const url = await computeRemoteUrl(uri, kind);
+        await vscode.env.openExternal(vscode.Uri.parse(url));
+        vscode.window.setStatusBarMessage('Opened remote URL: ' + url, 3000);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(message);
     }
 }
 
@@ -243,59 +151,18 @@ class RemoteFoldersProvider {
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-    const provider = new RemoteFoldersProvider();
-
-    context.subscriptions.push(
-        vscode.window.registerTreeDataProvider('remoteFoldersView', provider)
-    );
-
     context.subscriptions.push(
         vscode.commands.registerCommand('remoteFolders.openRemote',
-            /** @param {any} arg */
-            async (arg) => {
-                openRemoteForTarget(arg);
-            })
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand('remoteFolders.openRemoteFromExplorer',
-            /** @param {any} uri @param {any[]} [selectedUris] */
-            async (uri, selectedUris) => {
-                if (Array.isArray(selectedUris) && selectedUris.length > 1) {
-                    for (const u of selectedUris) {
-                        await openRemoteForTarget(u);
+            /** @param {any} arg @param {any[]} [selected] */
+            async (arg, selected) => {
+                if (Array.isArray(selected) && selected.length > 1) {
+                    for (const item of selected) {
+                        await openRemoteForTarget(item);
                     }
                 } else {
-                    await openRemoteForTarget(uri);
+                    await openRemoteForTarget(arg);
                 }
             })
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand('remoteFolders.refresh', () => {
-            provider.refresh();
-        })
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand('remoteFolders.openRemoteForActiveFile', async () => {
-            const activeEditor = vscode.window.activeTextEditor;
-            let targetUri;
-
-            if (activeEditor) {
-                targetUri = activeEditor.document.uri;
-            } else {
-                const workspaceFolders = vscode.workspace.workspaceFolders;
-                if (workspaceFolders && workspaceFolders.length > 0) {
-                    targetUri = workspaceFolders[0].uri;
-                } else {
-                    vscode.window.showErrorMessage('No active file or workspace folder found.');
-                    return;
-                }
-            }
-
-            await openRemoteForTarget(targetUri);
-        })
     );
 }
 

--- a/src/remoteUrl.js
+++ b/src/remoteUrl.js
@@ -6,8 +6,10 @@
  * @returns {{ base: string, provider: 'github'|'gitlab'|'bitbucket'|'azure'|'unknown', host: string, repoPath: string }}
  */
 function normalizeRemote(remote) {
-    let host = '';
-    let repoPath = '';
+    /** @type {string} */
+    let host;
+    /** @type {string} */
+    let repoPath;
     if (!remote) {
         return { base: '', provider: 'unknown', host: '', repoPath: '' };
     }


### PR DESCRIPTION
The extension now provides a right-click context menu action to open the Git remote URL for a file or folder in your default browser — available in both the Explorer and the Source Control views. The previously existing inline icon buttons, custom Remote Folders tree view, keybindings, command palette entries, and the active-file shortcut command have been removed. The right-click menu is the standard, discoverable VS Code interaction pattern for both surfaces.

- Fixes #12
- Fixes #11

## Changed: How you open a remote URL

Right-click any file or folder in the **Explorer**, or any changed file or folder group in the **Source Control** view, then choose **Open Remote URL in Browser**. That is now the only entry point.

## Removed: Custom Remote Folders view

The dedicated *Remote Folders* tree view in the Explorer side bar has been removed. All folder navigation goes through the regular Explorer.

## Removed: Inline icon buttons

No inline icon buttons appear on tree items or Explorer entries anymore. The action is reachable through the right-click context menu only.

## Removed: Keyboard shortcuts and command palette entry

The previous shortcuts (`Ctrl+Shift+O` / `Cmd+Shift+O` and `Ctrl+Alt+O` / `Cmd+Alt+O`) and the *Open Remote URL for Current File/Folder* command palette entry have been removed. Use the right-click menu instead.

## Removed: `remoteFolders.exclude` setting

This setting only affected the removed Remote Folders tree view and is no longer present. The `remoteFolders.preferBranch` setting is unchanged.

## Technical Details

- `package.json`: Removed `views`, `view/item/context`, `view/title`, `keybindings`, and the active-file/refresh/tree-view commands. Kept a single `remoteFolders.openRemote` command and registered it under `explorer/context`, `scm/resourceState/context` (individual changed files), and `scm/resourceFolder/context` (folder groups), all gated with `scmProvider == git`. Hidden from the command palette via a `commandPalette` `when: false` entry. Removed the `remoteFolders.exclude` configuration property.
- `src/extension.js`: Removed `RemoteFoldersProvider`, all tree-view registration, and the auxiliary commands. Kept `getGitApi`, `getRepositoryForUri`, `detectResourceKind`, `computeRemoteUrl`, and a unified `openRemoteForTarget` that resolves a `Uri` from any context-menu argument (Uri, tree item, or SCM `SourceControlResourceState` via `resourceUri`, or `SourceControlResourceFolder` via `uri`). Multi-select handled when the second argument is an array.
- `resources/`: Removed unused `open-external-dark.svg` / `open-external-light.svg` icons.
- **Implementation plan progress (#11)**: All three core tasks completed — `scm/resourceState/context`, `scm/resourceFolder/context`, and `scmProvider == git` gating. URL resolves to the current branch via `repo.state.HEAD.name` (no changes needed). Multi-select opens all selected items via the existing array-argument loop.